### PR TITLE
feat: Delegator V2 that returns Values Struct of Collection 

### DIFF
--- a/contracts/Delegator.sol
+++ b/contracts/Delegator.sol
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
-import "./Core/StateManager.sol";
 import "./Core/interface/ICollectionManager.sol";
 import "./IDelegator.sol";
 import "./randomNumber/IRandomNoClient.sol";
-import "./Core/parameters/ACL.sol";
 import "./Core/storage/Constants.sol";
 import "./Pause.sol";
 
@@ -13,7 +11,7 @@ import "./Pause.sol";
  * @notice Delegator acts as a bridge between the client and the protocol
  */
 
-contract Delegator is ACL, StateManager, Pause, IDelegator {
+contract Delegator is Pause, IDelegator {
     ICollectionManager public collectionManager;
     IRandomNoClient public randomNoManager;
 

--- a/contracts/Delegator.sol
+++ b/contracts/Delegator.sol
@@ -45,8 +45,10 @@ contract Delegator is ACL, StateManager, Pause, IDelegator {
     }
 
     /// @inheritdoc IDelegator
-    function getResult(bytes32 _name) external view override whenNotPaused returns (uint256, int8) {
-        return collectionManager.getResult(_name);
+    function getResult(bytes32 _name) external view override whenNotPaused returns (Value memory) {
+        uint16 collectionId = collectionManager.getCollectionID(_name);
+        (uint256 result, int8 power) = collectionManager.getResult(_name);
+        return Value(power, collectionId, _name, result);
     }
 
     /// @inheritdoc IDelegator

--- a/contracts/IDelegator.sol
+++ b/contracts/IDelegator.sol
@@ -1,7 +1,14 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
+import "./lib/Structs.sol";
 
 interface IDelegator {
+    struct Value {
+        int8 power;
+        uint16 collectionId;
+        bytes32 name;
+        uint256 value;
+    }
     /**
      * @dev updates the address of the Collection Manager contract from where the delegator will fetch
      * results of the oracle
@@ -28,9 +35,9 @@ interface IDelegator {
     /**
      * @dev using the hash of collection name, clients can query the result of that collection
      * @param _name bytes32 hash of the collection name
-     * @return result of the collection and its power
+     * @return value which is a struct of Value(power, collectionId, name, result)
      */
-    function getResult(bytes32 _name) external view returns (uint256, int8);
+    function getResult(bytes32 _name) external view returns (Value memory);
 
     /**
      * @dev using the collection id, clients can query the result of the collection

--- a/contracts/IDelegator.sol
+++ b/contracts/IDelegator.sol
@@ -9,6 +9,7 @@ interface IDelegator {
         bytes32 name;
         uint256 value;
     }
+
     /**
      * @dev updates the address of the Collection Manager contract from where the delegator will fetch
      * results of the oracle

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -32,6 +32,7 @@ const ENV_CHAIN_IDS = {
   mainnet: 1,
   goerli: 5,
   mumbai: 80001,
+  skale: 1517929550,
 };
 
 module.exports = {

--- a/migrations/deploy_delegator.js
+++ b/migrations/deploy_delegator.js
@@ -1,0 +1,34 @@
+/* eslint-disable no-console */
+
+const { ethers } = require('hardhat');
+const { readDeploymentFile, getdeployedContractInstance } = require('./migrationHelpers');
+const delegatorMigration = require('./src/7_deploy_delegator');
+
+async function main() {
+  const signers = await ethers.getSigners();
+  // Deploy smart contracts
+  await delegatorMigration();
+
+  const {
+    Delegator: delegatorAddress,
+  } = await readDeploymentFile();
+    // keccak256("PAUSE_ROLE")
+  const PAUSE_ROLE = '0x139c2898040ef16910dc9f44dc697df79363da767d8bc92f2e310312b816e46d';
+  const { contractInstance: delegatorv2 } = await getdeployedContractInstance('Delegator', delegatorAddress);
+  const pendingTransactions = [];
+  pendingTransactions.push(await delegatorv2.grantRole(PAUSE_ROLE, signers[0].address));
+  pendingTransactions.push(await delegatorv2.updateAddress('0xbF5c5AD799b2245BA36562BebfcbAbc5D508Eb84', '0xC2d1F555168021d107bDB85380890281b3947493'));
+
+  console.log('Waiting for post-deployment setup transactions to get confirmed');
+  for (let i = 0; i < pendingTransactions.length; i++) {
+    pendingTransactions[i].wait();
+  }
+  console.log('post deployment tx are complete', pendingTransactions);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/migrations/src/postDeploymentSetup.js
+++ b/migrations/src/postDeploymentSetup.js
@@ -101,7 +101,6 @@ module.exports = async () => {
   pendingTransactions.push(await rewardManager.grantRole(GOVERNANCE_ROLE, governanceAddress));
   pendingTransactions.push(await stakeManager.grantRole(GOVERNANCE_ROLE, governanceAddress));
   pendingTransactions.push(await voteManager.grantRole(GOVERNANCE_ROLE, governanceAddress));
-  pendingTransactions.push(await delegator.grantRole(GOVERNANCE_ROLE, governanceAddress));
   pendingTransactions.push(await randomNoManager.grantRole(GOVERNANCE_ROLE, governanceAddress));
 
   pendingTransactions.push(await blockManager.grantRole(BLOCK_CONFIRMER_ROLE, voteManagerAddress));
@@ -115,6 +114,7 @@ module.exports = async () => {
   pendingTransactions.push(await collectionManager.grantRole(REGISTRY_MODIFIER_ROLE, blockManagerAddress));
   pendingTransactions.push(await collectionManager.grantRole(COLLECTION_MODIFIER_ROLE, signers[0].address));
   pendingTransactions.push(await stakeManager.grantRole(PAUSE_ROLE, signers[0].address));
+  pendingTransactions.push(await delegator.grantRole(PAUSE_ROLE, signers[0].address));
   pendingTransactions.push(await governance.grantRole(GOVERNER_ROLE, signers[0].address));
   pendingTransactions.push(await voteManager.grantRole(SALT_MODIFIER_ROLE, blockManagerAddress));
   pendingTransactions.push(await voteManager.grantRole(DEPTH_MODIFIER_ROLE, collectionManagerAddress));

--- a/test/AssignCollectionsRandomly.js
+++ b/test/AssignCollectionsRandomly.js
@@ -154,9 +154,9 @@ describe('AssignCollectionsRandomly', function () {
       const collectionName = 'c2';
       const hName = utils.solidityKeccak256(['string'], [collectionName]);
       const result1 = await delegator.getResult(hName);
-      assertBNEqual(result1[0], 300);
+      assertBNEqual(result1[3], 300);
       const result2 = await delegator.getResult(utils.solidityKeccak256(['string'], ['c1']));
-      assertBNEqual(result2[0], 0);
+      assertBNEqual(result2[3], 0);
 
       await reset();
     });
@@ -232,7 +232,7 @@ describe('AssignCollectionsRandomly', function () {
       const collectionName = 'c2';
       const hName = utils.solidityKeccak256(['string'], [collectionName]);
       const result = await delegator.getResult(hName);
-      assertBNEqual(result[0], 300);
+      assertBNEqual(result[3], 300);
     });
 
     it('Staker Proposes revealed assets in-correctly', async () => {

--- a/test/Delegator.js
+++ b/test/Delegator.js
@@ -124,8 +124,8 @@ describe('Delegator', function () {
       const collectionName = 'Test Collection';
       const hName = utils.solidityKeccak256(['string'], [collectionName]);
       const result = await delegator.getResult(hName);
-      assertBNEqual(result[0], toBigNumber('100'));
-      assertBNEqual(result[1], toBigNumber('3'));
+      assertBNEqual(result[3], toBigNumber('100'));
+      assertBNEqual(result[0], toBigNumber('3'));
     });
 
     it('should be able to fetch result using id', async function () {
@@ -205,8 +205,8 @@ describe('Delegator', function () {
       const collectionName = 'Test Collection5';
       const hName = utils.solidityKeccak256(['string'], [collectionName]);
       const result = await delegator.getResult(hName);
-      assertBNEqual(result[0], toBigNumber('500'));
-      assertBNEqual(result[1], toBigNumber('2'));
+      assertBNEqual(result[3], toBigNumber('500'));
+      assertBNEqual(result[0], toBigNumber('2'));
     });
 
     it('should be able to fetch random number generated of last epoch', async function () {
@@ -294,8 +294,8 @@ describe('Delegator', function () {
       const result = await delegator.getResult(hName);
       const collectionID = await collectionManager.ids(hName);
       assertBNEqual(collectionID, toBigNumber('3'));
-      assertBNEqual(result[0], toBigNumber('300'));
-      assertBNEqual(result[1], toBigNumber('2'));
+      assertBNEqual(result[3], toBigNumber('300'));
+      assertBNEqual(result[0], toBigNumber('2'));
     });
 
     it('should not be able to create collection with same name', async function () {


### PR DESCRIPTION
- `getResult(name)`will now return a `Struct Value` that consists of `(power, collectionId, collectionName, result)` of the requested collection name.
- Updates the `IDelegator` interface so that this can be used by clients.

Deployment plan for staging([skale-testnet v3](https://staging-aware-chief-gianfar.explorer.staging-v3.skalenodes.com/)):

- Deployment script to deploy only the `Delegator.sol` contract 
- Grant `PAUSE_ROLE` to admin for Delegator in the postDeployment script
- `updateAddress(collectionManager, randomNoManager)` call this function with the previously deployed (currently live on staging oracle) Collection Manager  and RandomNoManger contract addresses. @SkandaBhat @SamAg19 


Resolves 
#985 
#986
#987 