### PR TITLE
feat: timestamp added and updated for each collection post block confirmation

### DIFF
--- a/contracts/Core/BlockManager.sol
+++ b/contracts/Core/BlockManager.sol
@@ -473,8 +473,8 @@ contract BlockManager is Initializable, BlockStorage, StateManager, BlockManager
     }
 
     /// @inheritdoc IBlockManager
-    function getLatestResults(uint16 id) external view override returns (uint256) {
-        return latestResults[id];
+    function getLatestResults(uint16 id) external view override returns (uint256, uint256) {
+        return (latestResults[id], latestResultTimestamp[id]);
     }
 
     /**
@@ -492,6 +492,7 @@ contract BlockManager is Initializable, BlockStorage, StateManager, BlockManager
         Structs.Block memory _block = blocks[epoch];
         for (uint256 i = 0; i < _block.ids.length; i++) {
             latestResults[_block.ids[i]] = _block.medians[i];
+            latestResultTimestamp[_block.ids[i]] = block.timestamp;
         }
 
         emit BlockConfirmed(epoch, _block.proposerId, _block.ids, block.timestamp, _block.medians);

--- a/contracts/Core/CollectionManager.sol
+++ b/contracts/Core/CollectionManager.sol
@@ -286,7 +286,7 @@ contract CollectionManager is Initializable, CollectionStorage, StateManager, Co
     }
 
     /// @inheritdoc ICollectionManager
-    function getResult(bytes32 _name) external view override returns (uint256, int8) {
+    function getResult(bytes32 _name) external view override returns (uint256, int8, uint256) {
         uint16 id = ids[_name];
         return getResultFromID(id);
     }
@@ -370,8 +370,9 @@ contract CollectionManager is Initializable, CollectionStorage, StateManager, Co
     }
 
     /// @inheritdoc ICollectionManager
-    function getResultFromID(uint16 _id) public view override returns (uint256, int8) {
-        return (blockManager.getLatestResults(_id), collections[_id].power);
+    function getResultFromID(uint16 _id) public view override returns (uint256, int8, uint256) {
+        (uint256 result, uint256 timestamp) = blockManager.getLatestResults(_id);
+        return (result, collections[_id].power, timestamp);
     }
 
     /**

--- a/contracts/Core/interface/IBlockManager.sol
+++ b/contracts/Core/interface/IBlockManager.sol
@@ -29,5 +29,5 @@ interface IBlockManager {
      * @notice Allows to get latest result of collection from id, used by delegator
      * @param id Collection ID
      */
-    function getLatestResults(uint16 id) external view returns (uint256);
+    function getLatestResults(uint16 id) external view returns (uint256, uint256);
 }

--- a/contracts/Core/interface/ICollectionManager.sol
+++ b/contracts/Core/interface/ICollectionManager.sol
@@ -70,17 +70,19 @@ interface ICollectionManager {
      * @notice returns the result of the collection based on the name sent by the client
      * @param _name the name of the collection in bytes32
      * @return result of the collection
+     * @return result timestamp of the collection
      * @return power of the resultant collection
      */
-    function getResult(bytes32 _name) external view returns (uint256, int8);
+    function getResult(bytes32 _name) external view returns (uint256, int8, uint256);
 
     /**
      * @notice returns the result of the collection based on the id sent by the client
      * @param _id the id of the collection
      * @return result of the collection
+     * @return result timestamp of the collection
      * @return power of the resultant collection
      */
-    function getResultFromID(uint16 _id) external view returns (uint256, int8);
+    function getResultFromID(uint16 _id) external view returns (uint256, int8, uint256);
 
     /**
      * @return epoch in which the registry needs to be updated

--- a/contracts/Core/storage/BlockStorage.sol
+++ b/contracts/Core/storage/BlockStorage.sol
@@ -13,6 +13,8 @@ contract BlockStorage {
     mapping(uint32 => uint32) public epochLastProposed;
     // @notice mapping for latest results of collection id->result
     mapping(uint16 => uint256) public latestResults;
+    // @notice mapping for latest results of collection id->result timestamp
+    mapping(uint16 => uint256) public latestResultTimestamp;
     /// @notice total number of proposed blocks in an epoch
     // slither-disable-next-line constable-states
     uint32 public numProposedBlocks;

--- a/contracts/Delegator.sol
+++ b/contracts/Delegator.sol
@@ -45,12 +45,12 @@ contract Delegator is ACL, StateManager, Pause, IDelegator {
     }
 
     /// @inheritdoc IDelegator
-    function getResult(bytes32 _name) external view override whenNotPaused returns (uint256, int8) {
+    function getResult(bytes32 _name) external view override whenNotPaused returns (uint256, int8, uint256) {
         return collectionManager.getResult(_name);
     }
 
     /// @inheritdoc IDelegator
-    function getResultFromID(uint16 _id) external view override whenNotPaused returns (uint256, int8) {
+    function getResultFromID(uint16 _id) external view override whenNotPaused returns (uint256, int8, uint256) {
         return collectionManager.getResultFromID(_id);
     }
 

--- a/contracts/IDelegator.sol
+++ b/contracts/IDelegator.sol
@@ -30,14 +30,14 @@ interface IDelegator {
      * @param _name bytes32 hash of the collection name
      * @return result of the collection and its power
      */
-    function getResult(bytes32 _name) external view returns (uint256, int8);
+    function getResult(bytes32 _name) external view returns (uint256, int8, uint256);
 
     /**
      * @dev using the collection id, clients can query the result of the collection
      * @param _id collection ID
      * @return result of the collection and its power
      */
-    function getResultFromID(uint16 _id) external view returns (uint256, int8);
+    function getResultFromID(uint16 _id) external view returns (uint256, int8, uint256);
 
     /**
      * @return ids of active collections in the oracle


### PR DESCRIPTION
## Problem Statement

The current implementation does not store the timestamp at which the latest result of a particular collection is set. Clients require a timestamp to authenticate whether the result being reported is the latest or not. 

fixes #989 

## Solution

- When the block is confirmed, the mapping of the collection id to timestamp `latestResultTimestamp` is updated along with the result of the collection. 
- When we try to get the result through the collection manager from the `getResult` function, it will return power, result and timestamp